### PR TITLE
Making changes to avoid Segmentation Fault on raspberry pi

### DIFF
--- a/detection_demo.py
+++ b/detection_demo.py
@@ -96,7 +96,7 @@ def main_images(predictor, model, object_names, in_dir, out_dir, device='cuda'):
     with torch.no_grad():
         for img_name in file_names:
             image = cv2.imread(img_name)
-
+            height, width, _ = image.shape
             start_time = time.time()
 
             output = predictor.predict(model, image)
@@ -108,8 +108,8 @@ def main_images(predictor, model, object_names, in_dir, out_dir, device='cuda'):
             boxes, labels, scores = [o.to("cpu").numpy() for o in output]
             for label, score, coords in zip(labels, scores, boxes):
                 r, g, b = COLOR_MAP[label]
-                c1 = (int(coords[0]), int(coords[1]))
-                c2 = (int(coords[2]), int(coords[3]))
+                c1 = (int(coords[0] * width), int(coords[1] * height))
+                c2 = (int(coords[2] * width), int(coords[3] * height))
                 cv2.rectangle(image, c1, c2, (r, g, b), thickness=RECT_BORDER_THICKNESS)
                 label_text = '{label}: {score:.2f}'.format(label=object_names[label], score=score)
                 t_size = cv2.getTextSize(label_text, FONT_SIZE, 1, TEXT_THICKNESS)[0]
@@ -141,7 +141,7 @@ def main_live(predictor, model, object_names, device='cuda'):
             ret, image = capture_device.read()
             if image is None:
                 continue
-
+            height, width, _ = image.shape
             start_time = time.time()
 
             output = predictor.predict(model, image)
@@ -155,8 +155,8 @@ def main_live(predictor, model, object_names, device='cuda'):
 
             for label, score, coords in zip(labels, scores, boxes):
                 r, g, b = COLOR_MAP[label]
-                c1 = (int(coords[0]), int(coords[1]))
-                c2 = (int(coords[2]), int(coords[3]))
+                c1 = (int(coords[0] * width), int(coords[1] * height))
+                c2 = (int(coords[2] * width), int(coords[3] * height))
                 cv2.rectangle(image, c1, c2, (r, g, b), thickness=RECT_BORDER_THICKNESS)
                 label_text = '{} {}'.format(object_names[label], int(score*100))
                 t_size = cv2.getTextSize(label_text, FONT_SIZE, 1, TEXT_THICKNESS)[0]

--- a/model/detection/box_predictor.py
+++ b/model/detection/box_predictor.py
@@ -26,7 +26,6 @@ class BoxPredictor(object):
         self.device = device
 
     def predict(self, model, image):
-        height, width, _ = image.shape
         image = self.transform(image)
         images = image.unsqueeze(0)
         images = images.to(self.device)
@@ -57,10 +56,7 @@ class BoxPredictor(object):
         # no object detected
         if not filtered_box_probs:
             return torch.empty(0, 4), torch.empty(0), torch.empty(0)
-        # concatenate all results
+
         filtered_box_probs = torch.cat(filtered_box_probs)
-        filtered_box_probs[:, 0] *= width
-        filtered_box_probs[:, 1] *= height
-        filtered_box_probs[:, 2] *= width
-        filtered_box_probs[:, 3] *= height
+
         return filtered_box_probs[:, :4], torch.tensor(filtered_labels), filtered_box_probs[:, 4]


### PR DESCRIPTION
When I tried to run ESPNETv2 in a raspberry pi environment I was having a problem trying to run it for a large amount of images. The network stopped running with the following message: Segmentation Fault.

After a debug process, I found that the problem was on the following lines:

        filtered_box_probs [:, 0] * = width
        filtered_box_probs [:, 1] * = height
        filtered_box_probs [:, 2] * = width
        filtered_box_probs [:, 3] * = height

In the box_predictor.py file

I believe these multiplication operations directly with tensors may be causing some problems in more limited environments (eg raspberry with 1gb ram and a 32 bit system). To do this, I made some changes to work around this issue, and succeeded in running ESPNETv2 on raspberry pi.

Summary of Changes: Basically excludes the above lines that were generating Segmentation Fault, and within the demo_detection.py file I added the multiplications in the coordinate values ​​directly. Since the multiplications are now with values ​​and not tensors, I got no error running the network for a large amount of time and with a large amount of images.