### PR TITLE
Allow input channel count to be changed

### DIFF
--- a/License
+++ b/License
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Sachin Mehta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/model/classification/espnetv2.py
+++ b/model/classification/espnetv2.py
@@ -57,19 +57,19 @@ class EESPNet(nn.Module):
 
         self.level1 = CBR(channels_in, out_channel_map[0], 3, 2)  # 112 L1
 
-        self.level2_0 = DownSampler(out_channel_map[0], out_channel_map[1], k=K[0], r_lim=recept_limit[0], reinf=self.input_reinforcement)  # out = 56
+        self.level2_0 = DownSampler(out_channel_map[0], out_channel_map[1], input2_nin=channels_in, k=K[0], r_lim=recept_limit[0], reinf=self.input_reinforcement)  # out = 56
 
-        self.level3_0 = DownSampler(out_channel_map[1], out_channel_map[2], k=K[1], r_lim=recept_limit[1], reinf=self.input_reinforcement) # out = 28
+        self.level3_0 = DownSampler(out_channel_map[1], out_channel_map[2], input2_nin=channels_in, k=K[1], r_lim=recept_limit[1], reinf=self.input_reinforcement) # out = 28
         self.level3 = nn.ModuleList()
         for i in range(reps_at_each_level[1]):
             self.level3.append(EESP(out_channel_map[2], out_channel_map[2], stride=1, k=K[2], r_lim=recept_limit[2]))
 
-        self.level4_0 = DownSampler(out_channel_map[2], out_channel_map[3], k=K[2], r_lim=recept_limit[2], reinf=self.input_reinforcement) #out = 14
+        self.level4_0 = DownSampler(out_channel_map[2], out_channel_map[3], input2_nin=channels_in, k=K[2], r_lim=recept_limit[2], reinf=self.input_reinforcement) #out = 14
         self.level4 = nn.ModuleList()
         for i in range(reps_at_each_level[2]):
             self.level4.append(EESP(out_channel_map[3], out_channel_map[3], stride=1, k=K[3], r_lim=recept_limit[3]))
 
-        self.level5_0 = DownSampler(out_channel_map[3], out_channel_map[4], k=K[3], r_lim=recept_limit[3]) #7
+        self.level5_0 = DownSampler(out_channel_map[3], out_channel_map[4], input2_nin=channels_in, k=K[3], r_lim=recept_limit[3]) #7
         self.level5 = nn.ModuleList()
         for i in range(reps_at_each_level[3]):
             self.level5.append(EESP(out_channel_map[4], out_channel_map[4], stride=1, k=K[4], r_lim=recept_limit[4]))

--- a/nn_layers/eesp.py
+++ b/nn_layers/eesp.py
@@ -101,7 +101,7 @@ class DownSampler(nn.Module):
     the final output.
     '''
 
-    def __init__(self, nin, nout, k=4, r_lim=9, reinf=True):
+    def __init__(self, nin, nout, input2_nin=config_inp_reinf, k=4, r_lim=9, reinf=True):
         '''
             :param nin: number of input channels
             :param nout: number of output channels
@@ -115,7 +115,7 @@ class DownSampler(nn.Module):
         self.avg = nn.AvgPool2d(kernel_size=3, padding=1, stride=2)
         if reinf:
             self.inp_reinf = nn.Sequential(
-                CBR(config_inp_reinf, config_inp_reinf, 3, 1),
+                CBR(input2_nin, config_inp_reinf, 3, 1),
                 CB(config_inp_reinf, nout, 1, 1)
             )
         self.act =  nn.PReLU(nout)

--- a/train_classification.py
+++ b/train_classification.py
@@ -44,7 +44,7 @@ def main(args):
             print_info_message('Loading pretrained basenet model weights')
             model_dict = model.state_dict()
 
-            overlap_dict = {k: v for k, v in pretrained_dict if k in model_dict.items()}
+            overlap_dict = {k: v for k, v in model_dict.items() if k in pretrained_dict}
 
             total_size_overlap = 0
             for k, v in enumerate(overlap_dict):

--- a/train_classification.py
+++ b/train_classification.py
@@ -44,7 +44,7 @@ def main(args):
             print_info_message('Loading pretrained basenet model weights')
             model_dict = model.state_dict()
 
-            overlap_dict = {k: v for k, v in model_dict.items() if k in pretrained_dict}
+            overlap_dict = {k: v for k, v in pretrained_dict if k in model_dict.items()}
 
             total_size_overlap = 0
             for k, v in enumerate(overlap_dict):


### PR DESCRIPTION
Update to ensure that different numbers of input channels can be handled without error. (Shortcut connection configuration assumed input channel count always equal to config_inp_reinf.)